### PR TITLE
Updating doc generator examples

### DIFF
--- a/lib/mix/tasks/conduit.gen.broker.ex
+++ b/lib/mix/tasks/conduit.gen.broker.ex
@@ -204,6 +204,19 @@ defmodule Mix.Tasks.Conduit.Gen.Broker do
   <% end %>
   Also, add your broker to the supervision hierarchy in your <%= @app %>.ex:
 
+  Elixir v1.5 or above:
+
+      def start(_type, _args) do
+        children = [
+          # ...
+          {<%= @module %>, []}
+        ]
+
+        supervise(children, strategy: :one_for_one)
+      end
+
+  Elixir v1.4 or below:
+
       def start(_type, _args) do
         children = [
           # ...

--- a/lib/mix/tasks/conduit.gen.broker.ex
+++ b/lib/mix/tasks/conduit.gen.broker.ex
@@ -31,6 +31,7 @@ defmodule Mix.Tasks.Conduit.Gen.Broker do
     path = get_path(parent_module)
     file = get_file(module)
     adapter = get_adapter(switches[:adapter])
+    module_app = get_app() |> String.capitalize()
 
     assigns = [
       path: path,
@@ -38,7 +39,8 @@ defmodule Mix.Tasks.Conduit.Gen.Broker do
       parent_module: parent_module,
       module: module,
       app: app,
-      adapter: adapter
+      adapter: adapter,
+      module_app: module_app
     ]
 
     create_broker(assigns)
@@ -212,7 +214,9 @@ defmodule Mix.Tasks.Conduit.Gen.Broker do
           {<%= @module %>, []}
         ]
 
-        supervise(children, strategy: :one_for_one)
+        opts = [strategy: :one_for_one, name: <%= @module_app %>.Supervisor]
+
+        Supervisor.start_link(children, opts)
       end
 
   Elixir v1.4 or below:

--- a/lib/mix/tasks/conduit.gen.broker.ex
+++ b/lib/mix/tasks/conduit.gen.broker.ex
@@ -31,7 +31,6 @@ defmodule Mix.Tasks.Conduit.Gen.Broker do
     path = get_path(parent_module)
     file = get_file(module)
     adapter = get_adapter(switches[:adapter])
-    module_app = get_app() |> String.capitalize()
 
     assigns = [
       path: path,
@@ -39,8 +38,7 @@ defmodule Mix.Tasks.Conduit.Gen.Broker do
       parent_module: parent_module,
       module: module,
       app: app,
-      adapter: adapter,
-      module_app: module_app
+      adapter: adapter
     ]
 
     create_broker(assigns)
@@ -214,7 +212,7 @@ defmodule Mix.Tasks.Conduit.Gen.Broker do
           {<%= @module %>, []}
         ]
 
-        opts = [strategy: :one_for_one, name: <%= @module_app %>.Supervisor]
+        opts = [strategy: :one_for_one]
 
         Supervisor.start_link(children, opts)
       end

--- a/test/mix/tasks/conduit.gen.broker_test.exs
+++ b/test/mix/tasks/conduit.gen.broker_test.exs
@@ -50,7 +50,9 @@ defmodule Mix.Tasks.Conduit.Gen.BrokerTest do
                      {ConduitQueue.Broker, []}
                    ]
 
-                   supervise(children, strategy: :one_for_one)
+                   opts = [strategy: :one_for_one, name: Conduit.Supervisor]
+
+                   Supervisor.start_link(children, opts)
                  end
 
              Elixir v1.4 or below:
@@ -98,7 +100,9 @@ defmodule Mix.Tasks.Conduit.Gen.BrokerTest do
                      {ConduitQueue.Broker, []}
                    ]
 
-                   supervise(children, strategy: :one_for_one)
+                   opts = [strategy: :one_for_one, name: Conduit.Supervisor]
+
+                   Supervisor.start_link(children, opts)
                  end
 
              Elixir v1.4 or below:

--- a/test/mix/tasks/conduit.gen.broker_test.exs
+++ b/test/mix/tasks/conduit.gen.broker_test.exs
@@ -42,6 +42,19 @@ defmodule Mix.Tasks.Conduit.Gen.BrokerTest do
 
              Also, add your broker to the supervision hierarchy in your conduit.ex:
 
+             Elixir v1.5 or above:
+
+                 def start(_type, _args) do
+                   children = [
+                     # ...
+                     {ConduitQueue.Broker, []}
+                   ]
+
+                   supervise(children, strategy: :one_for_one)
+                 end
+
+             Elixir v1.4 or below:
+
                  def start(_type, _args) do
                    children = [
                      # ...
@@ -76,6 +89,19 @@ defmodule Mix.Tasks.Conduit.Gen.BrokerTest do
                    secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role]
 
              Also, add your broker to the supervision hierarchy in your conduit.ex:
+
+             Elixir v1.5 or above:
+
+                 def start(_type, _args) do
+                   children = [
+                     # ...
+                     {ConduitQueue.Broker, []}
+                   ]
+
+                   supervise(children, strategy: :one_for_one)
+                 end
+
+             Elixir v1.4 or below:
 
                  def start(_type, _args) do
                    children = [

--- a/test/mix/tasks/conduit.gen.broker_test.exs
+++ b/test/mix/tasks/conduit.gen.broker_test.exs
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.Conduit.Gen.BrokerTest do
                      {ConduitQueue.Broker, []}
                    ]
 
-                   opts = [strategy: :one_for_one, name: Conduit.Supervisor]
+                   opts = [strategy: :one_for_one]
 
                    Supervisor.start_link(children, opts)
                  end
@@ -100,7 +100,7 @@ defmodule Mix.Tasks.Conduit.Gen.BrokerTest do
                      {ConduitQueue.Broker, []}
                    ]
 
-                   opts = [strategy: :one_for_one, name: Conduit.Supervisor]
+                   opts = [strategy: :one_for_one]
 
                    Supervisor.start_link(children, opts)
                  end


### PR DESCRIPTION
This PR address issue #11.

I added a new example showing how to add a new broker to the supervision hierarchy on Elixir >= 1.5. Kept the example for older Elixir versions for compatibility purposes.

New output:

```
Add conduit_amqp to your dependencies in mix.exs:

    {:conduit_amqp, "~> 0.4"}

Make sure to add the following to your config.exs:

    config :conduit, ConduitQueue.Broker,
      adapter: ConduitAMQP,
      url: "amqp://guest:guest@localhost:6782"

Also, add your broker to the supervision hierarchy in your conduit.ex:

Elixir v1.5 or above:

    def start(_type, _args) do
      children = [
        # ...
        {ConduitQueue.Broker, []}
      ]

      supervise(children, strategy: :one_for_one)
    end

Elixir v1.4 or below:

    def start(_type, _args) do
      children = [
        # ...
        supervisor(ConduitQueue.Broker, [])
      ]

      supervise(children, strategy: :one_for_one)
    end

```
