### PR TITLE
Fixing subscriber generator example

### DIFF
--- a/lib/mix/tasks/conduit.gen.subscriber.ex
+++ b/lib/mix/tasks/conduit.gen.subscriber.ex
@@ -198,9 +198,9 @@ defmodule Mix.Tasks.Conduit.Gen.Subscriber do
 
   embed_template(:subscriber_info, """
 
-  In an outgoing block in your <%= @broker_module %> add:
+  In an incoming block in your <%= @broker_module %> add:
 
-      subscribe :<%= @name %>, <%= @subscriber_name %>, to: "<%= @queue_name %>"
+      subscribe :<%= @name %>, <%= @subscriber_name %>, from: "<%= @queue_name %>"
 
   You may also want to define the queue in the configure block for <%= @broker_module %>:
 

--- a/test/mix/tasks/conduit.gen.subscriber_test.exs
+++ b/test/mix/tasks/conduit.gen.subscriber_test.exs
@@ -43,9 +43,9 @@ defmodule Mix.Tasks.Conduit.Gen.SubscriberTest do
              \e[32m* creating \e[0mtmp/lib/conduit_queue/subscribers/foo_subscriber.ex\e[0m
              \e[32m* creating \e[0mtmp/test/conduit_queue/subscribers/foo_subscriber_test.exs\e[0m
 
-             In an outgoing block in your ConduitQueue.Broker add:
+             In an incoming block in your ConduitQueue.Broker add:
 
-                 subscribe :foo, FooSubscriber, to: "conduit.foo"
+                 subscribe :foo, FooSubscriber, from: "conduit.foo"
 
              You may also want to define the queue in the configure block for ConduitQueue.Broker:
 
@@ -65,9 +65,9 @@ defmodule Mix.Tasks.Conduit.Gen.SubscriberTest do
              \e[32m* creating \e[0mtmp/lib/sqs/subscribers/foo_subscriber.ex\e[0m
              \e[32m* creating \e[0mtmp/test/sqs/subscribers/foo_subscriber_test.exs\e[0m
 
-             In an outgoing block in your Sqs.Broker add:
+             In an incoming block in your Sqs.Broker add:
 
-                 subscribe :foo, FooSubscriber, to: "conduit-foo"
+                 subscribe :foo, FooSubscriber, from: "conduit-foo"
 
              You may also want to define the queue in the configure block for Sqs.Broker:
 


### PR DESCRIPTION
This pr address issue #13.

Basically I changed subscriber generator to output the accepted config on broker.

New output:

> In an incoming block in your ExampleQueue.Broker add:
> 
>     subscribe :user_created, UserCreatedSubscriber, from: "example.user_created"

changed "**output**" to **incoming** and "**to**" on queue/topic to "**from**"