### PR TITLE
Fix Elixir 1.8 deprecation warning about plural time units.

### DIFF
--- a/lib/conduit/plug/log_incoming.ex
+++ b/lib/conduit/plug/log_incoming.ex
@@ -31,7 +31,7 @@ defmodule Conduit.Plug.LogIncoming do
     after
       Logger.log(level, fn ->
         stop = System.monotonic_time()
-        diff = System.convert_time_unit(stop - start, :native, :microseconds)
+        diff = System.convert_time_unit(stop - start, :native, :microsecond)
 
         ["Processed message from ", message.source, " in ", formatted_diff(diff)]
       end)

--- a/lib/conduit/plug/log_outgoing.ex
+++ b/lib/conduit/plug/log_outgoing.ex
@@ -31,7 +31,7 @@ defmodule Conduit.Plug.LogOutgoing do
     after
       Logger.log(level, fn ->
         stop = System.monotonic_time()
-        diff = System.convert_time_unit(stop - start, :native, :microseconds)
+        diff = System.convert_time_unit(stop - start, :native, :microsecond)
 
         ["Sent message to ", message.destination, " in ", formatted_diff(diff)]
       end)


### PR DESCRIPTION
Hi there,

This deprecation warning started appearing with Elixir 1.8.  This fix is backwards compatible to Elixir 1.4, but no longer supports Elixir 1.3.