### PR TITLE
Support dynamic message name on Conduit.Test functions

### DIFF
--- a/lib/conduit/test.ex
+++ b/lib/conduit/test.ex
@@ -76,28 +76,16 @@ defmodule Conduit.Test do
 
       MyApp.Broker.publish(:message, %Conduit.Message{})
       assert_message_published(:message)
+      message_name = :message
+      assert_message_published(message_name)
 
   """
   defmacro assert_message_published(name) when is_atom(name) do
     quote do: assert_received({:publish, _, unquote(name), _, _, _})
   end
 
-  defmacro assert_message_published(message_pattern) do
-    message_code = Macro.to_string(message_pattern)
-
-    quote do
-      assert_received({:publish, _, var!(name), unquote(message_pattern), _, _})
-
-      IO.warn("""
-      Calling assert_message_published/1 with a message pattern is deprecated. Replace with:
-
-          assert_message_published #{inspect(binding()[:name])}, #{unquote(message_code)}
-
-      Or
-
-          assert_message_published #{inspect(binding()[:name])}
-      """)
-    end
+  defmacro assert_message_published(name) do
+    quote do: assert_received({:publish, _, ^unquote(name), _, _, _})
   end
 
   @doc """
@@ -112,24 +100,16 @@ defmodule Conduit.Test do
       assert_message_published(:message, %Conduit.Message{body: body})
       assert_message_published(:message, message)
       assert_message_published(:message, ^message)
+      message_name = :message
+      assert_message_published(message_name, %Conduit.Message{body: body})
 
   """
   defmacro assert_message_published(name, message_pattern) when is_atom(name) do
     quote do: assert_received({:publish, _, unquote(name), unquote(message_pattern), _, _})
   end
 
-  defmacro assert_message_published(message_pattern, opts) do
-    message_code = Macro.to_string(message_pattern)
-
-    quote do
-      assert_received({:publish, _, var!(name), unquote(message_pattern), _, unquote(opts)})
-
-      IO.warn("""
-      Calling assert_message_published/2 with a message pattern as the first argument is deprecated. Replace with:
-
-          assert_message_published #{inspect(binding()[:name])}, #{unquote(message_code)}, #{inspect(unquote(opts))}
-      """)
-    end
+  defmacro assert_message_published(name, message_pattern) do
+    quote do: assert_received({:publish, _, ^unquote(name), unquote(message_pattern), _, _})
   end
 
   @doc """
@@ -144,10 +124,16 @@ defmodule Conduit.Test do
       assert_message_published(:message, %Conduit.Message{body: body}, [to: "queue"])
       assert_message_published(:message, message, [to: destination])
       assert_message_published(:message, ^message, ^opts)
+      message_name = :message
+      assert_message_published(message_name, %Conduit.Message{body: body}, [to: "queue"])
 
   """
   defmacro assert_message_published(name, message_pattern, opts_pattern) when is_atom(name) do
     quote do: assert_received({:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)})
+  end
+
+  defmacro assert_message_published(name, message_pattern, opts_pattern) do
+    quote do: assert_received({:publish, _, ^unquote(name), unquote(message_pattern), _, unquote(opts_pattern)})
   end
 
   @doc """
@@ -159,29 +145,16 @@ defmodule Conduit.Test do
   ## Examples
 
       refute_message_published(:message)
-      refute_message_published(_)
+      message_name = :message
+      refute_message_published(message_name)
 
   """
   defmacro refute_message_published(name) when is_atom(name) do
     quote do: refute_received({:publish, _, unquote(name), _, _, _})
   end
 
-  defmacro refute_message_published(message_pattern) do
-    message_code = Macro.to_string(message_pattern)
-
-    quote do
-      refute_received({:publish, _, _, unquote(message_pattern), _, _})
-
-      IO.warn("""
-      Calling refute_message_published/1 with a message pattern is deprecated. Replace with:
-
-          refute_message_published :publish_route, #{unquote(message_code)}
-
-      Or
-
-          refute_message_published :publish_route
-      """)
-    end
+  defmacro refute_message_published(name) do
+    quote do: refute_received({:publish, _, ^unquote(name), _, _, _})
   end
 
   @doc """
@@ -194,25 +167,16 @@ defmodule Conduit.Test do
 
       MyApp.Broker.publish(:message, %Conduit.Message{body: "bar"})
       refute_message_published(:message, %Conduit.Message{body: "foo"})
+      message_name = :message
+      refute_message_published(message_name, %Conduit.Message{body: "foo"})
 
   """
   defmacro refute_message_published(name, message_pattern) when is_atom(name) do
     quote do: refute_received({:publish, _, unquote(name), unquote(message_pattern), _, _})
   end
 
-  defmacro refute_message_published(message_pattern, opts_pattern) do
-    message_code = Macro.to_string(message_pattern)
-    opts_code = Macro.to_string(opts_pattern)
-
-    quote do
-      refute_received({:publish, _, _, unquote(message_pattern), _, unquote(opts_pattern)})
-
-      IO.warn("""
-      Calling refute_message_published/2 with a message pattern as the first argument is deprecated. Replace with:
-
-          refute_message_published :publish_route, #{unquote(message_code)}, #{unquote(opts_code)}
-      """)
-    end
+  defmacro refute_message_published(name, message_pattern) do
+    quote do: refute_received({:publish, _, ^unquote(name), unquote(message_pattern), _, _})
   end
 
   @doc """
@@ -225,10 +189,16 @@ defmodule Conduit.Test do
 
       MyApp.Broker.publish(:message, %Conduit.Message{body: "bar"}, to: "queue")
       refute_message_published(:message, %Conduit.Message{body: "bar"}, to: "elsewhere")
+      message_name = :message
+      refute_message_published(message_name, %Conduit.Message{body: "bar"}, to: "elsewhere")
 
   """
   defmacro refute_message_published(name, message_pattern, opts_pattern) when is_atom(name) do
     quote do: refute_received({:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)})
+  end
+
+  defmacro refute_message_published(name, message_pattern, opts_pattern) do
+    quote do: refute_received({:publish, _, ^unquote(name), unquote(message_pattern), _, unquote(opts_pattern)})
   end
 
   @doc """
@@ -240,29 +210,16 @@ defmodule Conduit.Test do
 
       MyApp.Broker.publish(:message, %Conduit.Message{})
       assert_message_publish(:message)
-      assert_message_publish(_)
+      message_name = :message
+      assert_message_publish(message_name)
 
   """
   defmacro assert_message_publish(name) when is_atom(name) do
     quote do: assert_receive({:publish, _, unquote(name), _, _, _}, 100)
   end
 
-  defmacro assert_message_publish(message_pattern) do
-    message_code = Macro.to_string(message_pattern)
-
-    quote do
-      assert_receive {:publish, _, var!(name), unquote(message_pattern), _, _}, 100
-
-      IO.warn("""
-      Calling assert_message_publish/1 with a message pattern is deprecated. Replace with:
-
-          assert_message_publish #{inspect(binding()[:name])}, #{unquote(message_code)}
-
-      Or
-
-          assert_message_publish #{inspect(binding()[:name])}
-      """)
-    end
+  defmacro assert_message_publish(name) do
+    quote do: assert_receive({:publish, _, ^unquote(name), _, _, _}, 100)
   end
 
   @doc """
@@ -276,6 +233,8 @@ defmodule Conduit.Test do
       MyApp.Broker.publish(:message, %Conduit.Message{})
       assert_message_publish(:message, 200)
       assert_message_publish(:message, ^message)
+      message_name = :message
+      assert_message_publish(message_name, 200)
 
   """
   defmacro assert_message_publish(name, timeout) when is_atom(name) and is_integer(timeout) do
@@ -286,22 +245,12 @@ defmodule Conduit.Test do
     quote do: assert_receive({:publish, _, unquote(name), unquote(message_pattern), _, _}, 100)
   end
 
-  defmacro assert_message_publish(message_pattern, timeout) when is_integer(timeout) do
-    message_code = Macro.to_string(message_pattern)
+  defmacro assert_message_publish(name, timeout) when is_integer(timeout) do
+    quote do: assert_receive({:publish, _, ^unquote(name), _, _, _}, unquote(timeout))
+  end
 
-    quote do
-      assert_receive {:publish, _, var!(name), unquote(message_pattern), _, _}, unquote(timeout)
-
-      IO.warn("""
-      Calling assert_message_publish/2 with a message pattern as the first argument is deprecated. Replace with:
-
-          assert_message_publish #{inspect(binding()[:name])}, #{unquote(message_code)}, #{unquote(timeout)}
-
-      Or
-
-          assert_message_publish #{inspect(binding()[:name])}, #{unquote(timeout)}
-      """)
-    end
+  defmacro assert_message_publish(name, message_pattern) do
+    quote do: assert_receive({:publish, _, ^unquote(name), unquote(message_pattern), _, _}, 100)
   end
 
   @doc """
@@ -316,6 +265,8 @@ defmodule Conduit.Test do
       assert_message_publish(:message, %{body: body}, 200)
       assert_message_publish(:message, %{body: body}, [to: "here"])
       assert_message_publish(:message, ^message, 300)
+      message_name = :message
+      assert_message_publish(message_name, %{body: body}, 200)
 
   """
   defmacro assert_message_publish(name, message_pattern, timeout) when is_atom(name) and is_integer(timeout) do
@@ -327,6 +278,18 @@ defmodule Conduit.Test do
   defmacro assert_message_publish(name, message_pattern, opts_pattern) when is_atom(name) do
     quote do
       assert_receive {:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)}, 100
+    end
+  end
+
+  defmacro assert_message_publish(name, message_pattern, timeout) when is_integer(timeout) do
+    quote do
+      assert_receive {:publish, _, ^unquote(name), unquote(message_pattern), _, _}, unquote(timeout)
+    end
+  end
+
+  defmacro assert_message_publish(name, message_pattern, opts_pattern) do
+    quote do
+      assert_receive {:publish, _, ^unquote(name), unquote(message_pattern), _, unquote(opts_pattern)}, 100
     end
   end
 
@@ -342,12 +305,21 @@ defmodule Conduit.Test do
       assert_message_publish(:message, %{body: body}, [to: "here"], 200)
       assert_message_publish(:message, message, [to: "here"], 300)
       assert_message_publish(:message, ^message, ^opts, 300)
+      message_name = :message
+      assert_message_publish(message_name, %{body: body}, [to: "here"], 200)
 
   """
   defmacro assert_message_publish(name, message_pattern, opts_pattern, timeout)
            when is_atom(name) and is_integer(timeout) do
     quote do
       assert_receive {:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)}, unquote(timeout)
+    end
+  end
+
+  defmacro assert_message_publish(name, message_pattern, opts_pattern, timeout)
+           when is_integer(timeout) do
+    quote do
+      assert_receive {:publish, _, ^unquote(name), unquote(message_pattern), _, unquote(opts_pattern)}, unquote(timeout)
     end
   end
 
@@ -359,28 +331,16 @@ defmodule Conduit.Test do
   ## Examples
 
       refute_message_publish(:message)
+      message_name = :message
+      refute_message_publish(message_name)
 
   """
   defmacro refute_message_publish(name) when is_atom(name) do
     quote do: refute_receive({:publish, _, unquote(name), _, _, _}, 100)
   end
 
-  defmacro refute_message_publish(message_pattern) do
-    message_code = Macro.to_string(message_pattern)
-
-    quote do
-      refute_receive({:publish, _, _, unquote(message_pattern), _, _}, 100)
-
-      IO.warn("""
-      Calling refute_message_publish/1 with a message pattern as the first argument is deprecated. Replace with:
-
-          refute_message_publish :publish_route, #{unquote(message_code)}
-
-      Or
-
-          refute_message_publish :publish_route
-      """)
-    end
+  defmacro refute_message_publish(name) do
+    quote do: refute_receive({:publish, _, ^unquote(name), _, _, _}, 100)
   end
 
   @doc """
@@ -394,6 +354,8 @@ defmodule Conduit.Test do
       refute_message_publish(:message, 200)
       refute_message_publish(:message, %{body: body})
       refute_message_publish(:message, ^message)
+      message_name = :message
+      refute_message_publish(message_name, 200)
 
   """
   defmacro refute_message_publish(name, timeout) when is_atom(name) and is_integer(timeout) do
@@ -404,22 +366,12 @@ defmodule Conduit.Test do
     quote do: refute_receive({:publish, _, unquote(name), unquote(message_pattern), _, _}, 100)
   end
 
-  defmacro refute_message_publish(message_pattern, timeout) when is_integer(timeout) do
-    message_code = Macro.to_string(message_pattern)
+  defmacro refute_message_publish(name, timeout) when is_integer(timeout) do
+    quote do: refute_receive({:publish, _, ^unquote(name), _, _, _}, unquote(timeout))
+  end
 
-    quote do
-      refute_receive {:publish, _, _, unquote(message_pattern), _, _}, unquote(timeout)
-
-      IO.warn("""
-      Calling refute_message_publish/2 with a message pattern as the first argument is deprecated. Replace with:
-
-          refute_message_publish :publish_route, #{unquote(message_code)}, #{unquote(timeout)}
-
-      Or
-
-          refute_message_publish :publish_route, #{unquote(timeout)}
-      """)
-    end
+  defmacro refute_message_publish(name, message_pattern) do
+    quote do: refute_receive({:publish, _, ^unquote(name), unquote(message_pattern), _, _}, 100)
   end
 
   @doc """
@@ -433,6 +385,8 @@ defmodule Conduit.Test do
       refute_message_publish(:message, %Conduit.Message{}, 200)
       refute_message_publish(:message, %{body: body}, [to: "elsewhere"])
       refute_message_publish(:message, ^message, ^options)
+      message_name = :message
+      refute_message_publish(message_name, %Conduit.Message{}, 200)
 
   """
   defmacro refute_message_publish(name, message_pattern, timeout) when is_atom(name) and is_integer(timeout) do
@@ -441,6 +395,14 @@ defmodule Conduit.Test do
 
   defmacro refute_message_publish(name, message_pattern, opts_pattern) when is_atom(name) do
     quote do: refute_receive({:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)}, 100)
+  end
+
+  defmacro refute_message_publish(name, message_pattern, timeout) when is_integer(timeout) do
+    quote do: refute_receive({:publish, _, ^unquote(name), unquote(message_pattern), _, _}, unquote(timeout))
+  end
+
+  defmacro refute_message_publish(name, message_pattern, opts_pattern) do
+    quote do: refute_receive({:publish, _, ^unquote(name), unquote(message_pattern), _, unquote(opts_pattern)}, 100)
   end
 
   @doc """
@@ -454,6 +416,8 @@ defmodule Conduit.Test do
       refute_message_publish(:message, %Conduit.Message{}, [to: "elsewhere"], 200)
       refute_message_publish(:message, %{body: body}, [to: "elsewhere"], 10)
       refute_message_publish(:message, ^message, ^options, 50)
+      message_name = :message
+      refute_message_publish(message_name, %Conduit.Message{}, [to: "elsewhere"], 200)
 
   """
   defmacro refute_message_publish(name, message_pattern, opts_pattern, timeout)
@@ -461,6 +425,16 @@ defmodule Conduit.Test do
     quote do
       refute_receive(
         {:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)},
+        unquote(timeout)
+      )
+    end
+  end
+
+  defmacro refute_message_publish(name, message_pattern, opts_pattern, timeout)
+           when is_integer(timeout) do
+    quote do
+      refute_receive(
+        {:publish, _, ^unquote(name), unquote(message_pattern), _, unquote(opts_pattern)},
         unquote(timeout)
       )
     end

--- a/lib/conduit/test.ex
+++ b/lib/conduit/test.ex
@@ -77,15 +77,11 @@ defmodule Conduit.Test do
       MyApp.Broker.publish(:message, %Conduit.Message{})
       assert_message_published(:message)
       message_name = :message
-      assert_message_published(message_name)
+      assert_message_published(^message_name)
 
   """
-  defmacro assert_message_published(name) when is_atom(name) do
-    quote do: assert_received({:publish, _, unquote(name), _, _, _})
-  end
-
   defmacro assert_message_published(name) do
-    quote do: assert_received({:publish, _, ^unquote(name), _, _, _})
+    quote do: assert_received({:publish, _, unquote(name), _, _, _})
   end
 
   @doc """
@@ -101,15 +97,11 @@ defmodule Conduit.Test do
       assert_message_published(:message, message)
       assert_message_published(:message, ^message)
       message_name = :message
-      assert_message_published(message_name, %Conduit.Message{body: body})
+      assert_message_published(^message_name, %Conduit.Message{body: body})
 
   """
-  defmacro assert_message_published(name, message_pattern) when is_atom(name) do
-    quote do: assert_received({:publish, _, unquote(name), unquote(message_pattern), _, _})
-  end
-
   defmacro assert_message_published(name, message_pattern) do
-    quote do: assert_received({:publish, _, ^unquote(name), unquote(message_pattern), _, _})
+    quote do: assert_received({:publish, _, unquote(name), unquote(message_pattern), _, _})
   end
 
   @doc """
@@ -125,15 +117,11 @@ defmodule Conduit.Test do
       assert_message_published(:message, message, [to: destination])
       assert_message_published(:message, ^message, ^opts)
       message_name = :message
-      assert_message_published(message_name, %Conduit.Message{body: body}, [to: "queue"])
+      assert_message_published(^message_name, %Conduit.Message{body: body}, [to: "queue"])
 
   """
-  defmacro assert_message_published(name, message_pattern, opts_pattern) when is_atom(name) do
-    quote do: assert_received({:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)})
-  end
-
   defmacro assert_message_published(name, message_pattern, opts_pattern) do
-    quote do: assert_received({:publish, _, ^unquote(name), unquote(message_pattern), _, unquote(opts_pattern)})
+    quote do: assert_received({:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)})
   end
 
   @doc """
@@ -146,15 +134,11 @@ defmodule Conduit.Test do
 
       refute_message_published(:message)
       message_name = :message
-      refute_message_published(message_name)
+      refute_message_published(^message_name)
 
   """
-  defmacro refute_message_published(name) when is_atom(name) do
-    quote do: refute_received({:publish, _, unquote(name), _, _, _})
-  end
-
   defmacro refute_message_published(name) do
-    quote do: refute_received({:publish, _, ^unquote(name), _, _, _})
+    quote do: refute_received({:publish, _, unquote(name), _, _, _})
   end
 
   @doc """
@@ -168,15 +152,11 @@ defmodule Conduit.Test do
       MyApp.Broker.publish(:message, %Conduit.Message{body: "bar"})
       refute_message_published(:message, %Conduit.Message{body: "foo"})
       message_name = :message
-      refute_message_published(message_name, %Conduit.Message{body: "foo"})
+      refute_message_published(^message_name, %Conduit.Message{body: "foo"})
 
   """
-  defmacro refute_message_published(name, message_pattern) when is_atom(name) do
-    quote do: refute_received({:publish, _, unquote(name), unquote(message_pattern), _, _})
-  end
-
   defmacro refute_message_published(name, message_pattern) do
-    quote do: refute_received({:publish, _, ^unquote(name), unquote(message_pattern), _, _})
+    quote do: refute_received({:publish, _, unquote(name), unquote(message_pattern), _, _})
   end
 
   @doc """
@@ -190,15 +170,11 @@ defmodule Conduit.Test do
       MyApp.Broker.publish(:message, %Conduit.Message{body: "bar"}, to: "queue")
       refute_message_published(:message, %Conduit.Message{body: "bar"}, to: "elsewhere")
       message_name = :message
-      refute_message_published(message_name, %Conduit.Message{body: "bar"}, to: "elsewhere")
+      refute_message_published(^message_name, %Conduit.Message{body: "bar"}, to: "elsewhere")
 
   """
-  defmacro refute_message_published(name, message_pattern, opts_pattern) when is_atom(name) do
-    quote do: refute_received({:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)})
-  end
-
   defmacro refute_message_published(name, message_pattern, opts_pattern) do
-    quote do: refute_received({:publish, _, ^unquote(name), unquote(message_pattern), _, unquote(opts_pattern)})
+    quote do: refute_received({:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)})
   end
 
   @doc """
@@ -211,15 +187,11 @@ defmodule Conduit.Test do
       MyApp.Broker.publish(:message, %Conduit.Message{})
       assert_message_publish(:message)
       message_name = :message
-      assert_message_publish(message_name)
+      assert_message_publish(^message_name)
 
   """
-  defmacro assert_message_publish(name) when is_atom(name) do
-    quote do: assert_receive({:publish, _, unquote(name), _, _, _}, 100)
-  end
-
   defmacro assert_message_publish(name) do
-    quote do: assert_receive({:publish, _, ^unquote(name), _, _, _}, 100)
+    quote do: assert_receive({:publish, _, unquote(name), _, _, _}, 100)
   end
 
   @doc """
@@ -234,23 +206,15 @@ defmodule Conduit.Test do
       assert_message_publish(:message, 200)
       assert_message_publish(:message, ^message)
       message_name = :message
-      assert_message_publish(message_name, 200)
+      assert_message_publish(^message_name, 200)
 
   """
-  defmacro assert_message_publish(name, timeout) when is_atom(name) and is_integer(timeout) do
+  defmacro assert_message_publish(name, timeout) when is_integer(timeout) do
     quote do: assert_receive({:publish, _, unquote(name), _, _, _}, unquote(timeout))
   end
 
-  defmacro assert_message_publish(name, message_pattern) when is_atom(name) do
-    quote do: assert_receive({:publish, _, unquote(name), unquote(message_pattern), _, _}, 100)
-  end
-
-  defmacro assert_message_publish(name, timeout) when is_integer(timeout) do
-    quote do: assert_receive({:publish, _, ^unquote(name), _, _, _}, unquote(timeout))
-  end
-
   defmacro assert_message_publish(name, message_pattern) do
-    quote do: assert_receive({:publish, _, ^unquote(name), unquote(message_pattern), _, _}, 100)
+    quote do: assert_receive({:publish, _, unquote(name), unquote(message_pattern), _, _}, 100)
   end
 
   @doc """
@@ -266,30 +230,18 @@ defmodule Conduit.Test do
       assert_message_publish(:message, %{body: body}, [to: "here"])
       assert_message_publish(:message, ^message, 300)
       message_name = :message
-      assert_message_publish(message_name, %{body: body}, 200)
+      assert_message_publish(^message_name, %{body: body}, 200)
 
   """
-  defmacro assert_message_publish(name, message_pattern, timeout) when is_atom(name) and is_integer(timeout) do
+  defmacro assert_message_publish(name, message_pattern, timeout) when is_integer(timeout) do
     quote do
       assert_receive {:publish, _, unquote(name), unquote(message_pattern), _, _}, unquote(timeout)
     end
   end
 
-  defmacro assert_message_publish(name, message_pattern, opts_pattern) when is_atom(name) do
-    quote do
-      assert_receive {:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)}, 100
-    end
-  end
-
-  defmacro assert_message_publish(name, message_pattern, timeout) when is_integer(timeout) do
-    quote do
-      assert_receive {:publish, _, ^unquote(name), unquote(message_pattern), _, _}, unquote(timeout)
-    end
-  end
-
   defmacro assert_message_publish(name, message_pattern, opts_pattern) do
     quote do
-      assert_receive {:publish, _, ^unquote(name), unquote(message_pattern), _, unquote(opts_pattern)}, 100
+      assert_receive {:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)}, 100
     end
   end
 
@@ -306,20 +258,12 @@ defmodule Conduit.Test do
       assert_message_publish(:message, message, [to: "here"], 300)
       assert_message_publish(:message, ^message, ^opts, 300)
       message_name = :message
-      assert_message_publish(message_name, %{body: body}, [to: "here"], 200)
+      assert_message_publish(^message_name, %{body: body}, [to: "here"], 200)
 
   """
-  defmacro assert_message_publish(name, message_pattern, opts_pattern, timeout)
-           when is_atom(name) and is_integer(timeout) do
+  defmacro assert_message_publish(name, message_pattern, opts_pattern, timeout) when is_integer(timeout) do
     quote do
       assert_receive {:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)}, unquote(timeout)
-    end
-  end
-
-  defmacro assert_message_publish(name, message_pattern, opts_pattern, timeout)
-           when is_integer(timeout) do
-    quote do
-      assert_receive {:publish, _, ^unquote(name), unquote(message_pattern), _, unquote(opts_pattern)}, unquote(timeout)
     end
   end
 
@@ -332,15 +276,11 @@ defmodule Conduit.Test do
 
       refute_message_publish(:message)
       message_name = :message
-      refute_message_publish(message_name)
+      refute_message_publish(^message_name)
 
   """
-  defmacro refute_message_publish(name) when is_atom(name) do
-    quote do: refute_receive({:publish, _, unquote(name), _, _, _}, 100)
-  end
-
   defmacro refute_message_publish(name) do
-    quote do: refute_receive({:publish, _, ^unquote(name), _, _, _}, 100)
+    quote do: refute_receive({:publish, _, unquote(name), _, _, _}, 100)
   end
 
   @doc """
@@ -355,23 +295,15 @@ defmodule Conduit.Test do
       refute_message_publish(:message, %{body: body})
       refute_message_publish(:message, ^message)
       message_name = :message
-      refute_message_publish(message_name, 200)
+      refute_message_publish(^message_name, 200)
 
   """
-  defmacro refute_message_publish(name, timeout) when is_atom(name) and is_integer(timeout) do
+  defmacro refute_message_publish(name, timeout) when is_integer(timeout) do
     quote do: refute_receive({:publish, _, unquote(name), _, _, _}, unquote(timeout))
   end
 
-  defmacro refute_message_publish(name, message_pattern) when is_atom(name) do
-    quote do: refute_receive({:publish, _, unquote(name), unquote(message_pattern), _, _}, 100)
-  end
-
-  defmacro refute_message_publish(name, timeout) when is_integer(timeout) do
-    quote do: refute_receive({:publish, _, ^unquote(name), _, _, _}, unquote(timeout))
-  end
-
   defmacro refute_message_publish(name, message_pattern) do
-    quote do: refute_receive({:publish, _, ^unquote(name), unquote(message_pattern), _, _}, 100)
+    quote do: refute_receive({:publish, _, unquote(name), unquote(message_pattern), _, _}, 100)
   end
 
   @doc """
@@ -386,23 +318,15 @@ defmodule Conduit.Test do
       refute_message_publish(:message, %{body: body}, [to: "elsewhere"])
       refute_message_publish(:message, ^message, ^options)
       message_name = :message
-      refute_message_publish(message_name, %Conduit.Message{}, 200)
+      refute_message_publish(^message_name, %Conduit.Message{}, 200)
 
   """
-  defmacro refute_message_publish(name, message_pattern, timeout) when is_atom(name) and is_integer(timeout) do
+  defmacro refute_message_publish(name, message_pattern, timeout) when is_integer(timeout) do
     quote do: refute_receive({:publish, _, unquote(name), unquote(message_pattern), _, _}, unquote(timeout))
   end
 
-  defmacro refute_message_publish(name, message_pattern, opts_pattern) when is_atom(name) do
-    quote do: refute_receive({:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)}, 100)
-  end
-
-  defmacro refute_message_publish(name, message_pattern, timeout) when is_integer(timeout) do
-    quote do: refute_receive({:publish, _, ^unquote(name), unquote(message_pattern), _, _}, unquote(timeout))
-  end
-
   defmacro refute_message_publish(name, message_pattern, opts_pattern) do
-    quote do: refute_receive({:publish, _, ^unquote(name), unquote(message_pattern), _, unquote(opts_pattern)}, 100)
+    quote do: refute_receive({:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)}, 100)
   end
 
   @doc """
@@ -417,24 +341,13 @@ defmodule Conduit.Test do
       refute_message_publish(:message, %{body: body}, [to: "elsewhere"], 10)
       refute_message_publish(:message, ^message, ^options, 50)
       message_name = :message
-      refute_message_publish(message_name, %Conduit.Message{}, [to: "elsewhere"], 200)
+      refute_message_publish(^message_name, %Conduit.Message{}, [to: "elsewhere"], 200)
 
   """
-  defmacro refute_message_publish(name, message_pattern, opts_pattern, timeout)
-           when is_atom(name) and is_integer(timeout) do
+  defmacro refute_message_publish(name, message_pattern, opts_pattern, timeout) when is_integer(timeout) do
     quote do
       refute_receive(
         {:publish, _, unquote(name), unquote(message_pattern), _, unquote(opts_pattern)},
-        unquote(timeout)
-      )
-    end
-  end
-
-  defmacro refute_message_publish(name, message_pattern, opts_pattern, timeout)
-           when is_integer(timeout) do
-    quote do
-      refute_receive(
-        {:publish, _, ^unquote(name), unquote(message_pattern), _, unquote(opts_pattern)},
         unquote(timeout)
       )
     end

--- a/test/conduit/test_test.exs
+++ b/test/conduit/test_test.exs
@@ -29,7 +29,7 @@ defmodule Conduit.TestSharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     message_name = :message
-    assert_message_published message_name
+    assert_message_published ^message_name
   end
 
   test "assert_message_published/2" do
@@ -40,7 +40,7 @@ defmodule Conduit.TestSharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     message_name = :message
-    assert_message_published message_name, %Conduit.Message{}
+    assert_message_published ^message_name, %Conduit.Message{}
   end
 
   test "assert_message_published/3" do
@@ -51,28 +51,28 @@ defmodule Conduit.TestSharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     message_name = :message
-    assert_message_published(message_name, %Conduit.Message{}, to: "somewhere")
+    assert_message_published(^message_name, %Conduit.Message{}, to: "somewhere")
   end
 
   test "refute_message_published/1" do
     refute_message_published :message
 
     message_name = :message
-    refute_message_published message_name
+    refute_message_published ^message_name
   end
 
   test "refute_message_published/2" do
     refute_message_published :message, %Conduit.Message{}
 
     message_name = :message
-    refute_message_published message_name, %Conduit.Message{}
+    refute_message_published ^message_name, %Conduit.Message{}
   end
 
   test "refute_message_published/3" do
     refute_message_published(:message, %Conduit.Message{}, to: "somewhere")
 
     message_name = :message
-    refute_message_published(message_name, %Conduit.Message{}, to: "somewhere")
+    refute_message_published(^message_name, %Conduit.Message{}, to: "somewhere")
   end
 
   test "assert_message_publish/1" do
@@ -83,7 +83,7 @@ defmodule Conduit.TestSharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     message_name = :message
-    assert_message_publish(message_name)
+    assert_message_publish(^message_name)
   end
 
   test "assert_message_publish/2" do
@@ -94,7 +94,7 @@ defmodule Conduit.TestSharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     message_name = :message
-    assert_message_publish message_name, 10
+    assert_message_publish ^message_name, 10
   end
 
   test "assert_message_publish/3" do
@@ -105,7 +105,7 @@ defmodule Conduit.TestSharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     message_name = :message
-    assert_message_publish(message_name, %Conduit.Message{}, 10)
+    assert_message_publish(^message_name, %Conduit.Message{}, 10)
   end
 
   test "assert_message_publish/4" do
@@ -116,14 +116,14 @@ defmodule Conduit.TestSharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     message_name = :message
-    assert_message_publish(message_name, %Conduit.Message{}, [to: "somewhere"], 10)
+    assert_message_publish(^message_name, %Conduit.Message{}, [to: "somewhere"], 10)
   end
 
   test "refute_message_publish/1" do
     refute_message_publish :message
 
     message_name = :message
-    refute_message_publish message_name
+    refute_message_publish ^message_name
   end
 
   test "refute_message_publish/2" do
@@ -132,9 +132,9 @@ defmodule Conduit.TestSharedTest do
     refute_message_publish :message, 10
 
     message_name = :message
-    refute_message_publish message_name, %Conduit.Message{}
+    refute_message_publish ^message_name, %Conduit.Message{}
 
-    refute_message_publish message_name, 10
+    refute_message_publish ^message_name, 10
   end
 
   test "refute_message_publish/3" do
@@ -143,16 +143,16 @@ defmodule Conduit.TestSharedTest do
     refute_message_publish(:message, %Conduit.Message{}, 10)
 
     message_name = :message
-    refute_message_publish(message_name, %Conduit.Message{}, to: "somewhere")
+    refute_message_publish(^message_name, %Conduit.Message{}, to: "somewhere")
 
-    refute_message_publish(message_name, %Conduit.Message{}, 10)
+    refute_message_publish(^message_name, %Conduit.Message{}, 10)
   end
 
   test "refute_message_publish/4" do
     refute_message_publish(:message, %Conduit.Message{}, [to: "somewhere"], 10)
 
     message_name = :message
-    refute_message_publish(message_name, %Conduit.Message{}, [to: "somewhere"], 10)
+    refute_message_publish(^message_name, %Conduit.Message{}, [to: "somewhere"], 10)
   end
 end
 
@@ -186,7 +186,7 @@ defmodule Conduit.TestUnsharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     message_name = :message
-    assert_message_published message_name
+    assert_message_published ^message_name
   end
 
   test "assert_message_published/2" do
@@ -197,7 +197,7 @@ defmodule Conduit.TestUnsharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     message_name = :message
-    assert_message_published message_name, %Conduit.Message{}
+    assert_message_published ^message_name, %Conduit.Message{}
   end
 
   test "assert_message_published/3" do
@@ -208,28 +208,28 @@ defmodule Conduit.TestUnsharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     message_name = :message
-    assert_message_published(message_name, %Conduit.Message{}, to: "somewhere")
+    assert_message_published(^message_name, %Conduit.Message{}, to: "somewhere")
   end
 
   test "refute_message_published/1" do
     refute_message_published :message
 
     message_name = :message
-    refute_message_published message_name
+    refute_message_published ^message_name
   end
 
   test "refute_message_published/2" do
     refute_message_published :message, %Conduit.Message{}
 
     message_name = :message
-    refute_message_published message_name, %Conduit.Message{}
+    refute_message_published ^message_name, %Conduit.Message{}
   end
 
   test "refute_message_published/3" do
     refute_message_published(:message, %Conduit.Message{}, to: "somewhere")
 
     message_name = :message
-    refute_message_published(message_name, %Conduit.Message{}, to: "somewhere")
+    refute_message_published(^message_name, %Conduit.Message{}, to: "somewhere")
   end
 
   test "assert_message_publish/1" do
@@ -240,7 +240,7 @@ defmodule Conduit.TestUnsharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     message_name = :message
-    assert_message_publish(message_name)
+    assert_message_publish(^message_name)
   end
 
   test "assert_message_publish/2" do
@@ -255,11 +255,11 @@ defmodule Conduit.TestUnsharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     message_name = :message
-    assert_message_publish message_name, %Conduit.Message{}
+    assert_message_publish ^message_name, %Conduit.Message{}
 
     Broker.publish(%Conduit.Message{}, :message)
 
-    assert_message_publish message_name, 10
+    assert_message_publish ^message_name, 10
   end
 
   test "assert_message_publish/3" do
@@ -274,11 +274,11 @@ defmodule Conduit.TestUnsharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     message_name = :message
-    assert_message_publish(message_name, %Conduit.Message{}, to: "somewhere")
+    assert_message_publish(^message_name, %Conduit.Message{}, to: "somewhere")
 
     Broker.publish(%Conduit.Message{}, :message)
 
-    assert_message_publish(message_name, %Conduit.Message{}, 10)
+    assert_message_publish(^message_name, %Conduit.Message{}, 10)
   end
 
   test "assert_message_publish/4" do
@@ -289,14 +289,14 @@ defmodule Conduit.TestUnsharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     message_name = :message
-    assert_message_publish(message_name, %Conduit.Message{}, [to: "somewhere"], 10)
+    assert_message_publish(^message_name, %Conduit.Message{}, [to: "somewhere"], 10)
   end
 
   test "refute_message_publish/1" do
     refute_message_publish :message
 
     message_name = :message
-    refute_message_publish message_name
+    refute_message_publish ^message_name
   end
 
   test "refute_message_publish/2" do
@@ -305,9 +305,9 @@ defmodule Conduit.TestUnsharedTest do
     refute_message_publish :message, 10
 
     message_name = :message
-    refute_message_publish message_name, %Conduit.Message{}
+    refute_message_publish ^message_name, %Conduit.Message{}
 
-    refute_message_publish message_name, 10
+    refute_message_publish ^message_name, 10
   end
 
   test "refute_message_publish/3" do
@@ -316,15 +316,15 @@ defmodule Conduit.TestUnsharedTest do
     refute_message_publish(:message, %Conduit.Message{}, 10)
 
     message_name = :message
-    refute_message_publish(message_name, %Conduit.Message{}, to: "somewhere")
+    refute_message_publish(^message_name, %Conduit.Message{}, to: "somewhere")
 
-    refute_message_publish(message_name, %Conduit.Message{}, 10)
+    refute_message_publish(^message_name, %Conduit.Message{}, 10)
   end
 
   test "refute_message_publish/4" do
     refute_message_publish(:message, %Conduit.Message{}, [to: "somewhere"], 10)
 
     message_name = :message
-    refute_message_publish(message_name, %Conduit.Message{}, [to: "somewhere"], 10)
+    refute_message_publish(^message_name, %Conduit.Message{}, [to: "somewhere"], 10)
   end
 end

--- a/test/conduit/test_test.exs
+++ b/test/conduit/test_test.exs
@@ -1,7 +1,6 @@
 defmodule Conduit.TestSharedTest do
   use ExUnit.Case, async: false
   use Conduit.Test, shared: true
-  import ExUnit.CaptureIO
 
   setup do
     Application.put_env(
@@ -29,9 +28,8 @@ defmodule Conduit.TestSharedTest do
 
     Broker.publish(%Conduit.Message{}, :message)
 
-    assert capture_io(:stderr, fn ->
-             assert_message_published %Conduit.Message{}
-           end) =~ "Calling assert_message_published"
+    message_name = :message
+    assert_message_published message_name
   end
 
   test "assert_message_published/2" do
@@ -41,35 +39,40 @@ defmodule Conduit.TestSharedTest do
 
     Broker.publish(%Conduit.Message{}, :message)
 
-    assert capture_io(:stderr, fn ->
-             assert_message_published %Conduit.Message{}, to: "somewhere"
-           end) =~ "Calling assert_message_published"
+    message_name = :message
+    assert_message_published message_name, %Conduit.Message{}
   end
 
   test "assert_message_published/3" do
     Broker.publish(%Conduit.Message{}, :message)
 
     assert_message_published(:message, %Conduit.Message{}, to: "somewhere")
+
+    Broker.publish(%Conduit.Message{}, :message)
+
+    message_name = :message
+    assert_message_published(message_name, %Conduit.Message{}, to: "somewhere")
   end
 
   test "refute_message_published/1" do
     refute_message_published :message
 
-    assert capture_io(:stderr, fn ->
-             refute_message_published %Conduit.Message{}
-           end) =~ "Calling refute_message_published"
+    message_name = :message
+    refute_message_published message_name
   end
 
   test "refute_message_published/2" do
     refute_message_published :message, %Conduit.Message{}
 
-    assert capture_io(:stderr, fn ->
-             refute_message_published %Conduit.Message{}, to: "somewhere"
-           end) =~ "Calling refute_message_published"
+    message_name = :message
+    refute_message_published message_name, %Conduit.Message{}
   end
 
   test "refute_message_published/3" do
     refute_message_published(:message, %Conduit.Message{}, to: "somewhere")
+
+    message_name = :message
+    refute_message_published(message_name, %Conduit.Message{}, to: "somewhere")
   end
 
   test "assert_message_publish/1" do
@@ -79,9 +82,8 @@ defmodule Conduit.TestSharedTest do
 
     Broker.publish(%Conduit.Message{}, :message)
 
-    assert capture_io(:stderr, fn ->
-             assert_message_publish %Conduit.Message{}
-           end) =~ "Calling assert_message_publish"
+    message_name = :message
+    assert_message_publish(message_name)
   end
 
   test "assert_message_publish/2" do
@@ -91,7 +93,8 @@ defmodule Conduit.TestSharedTest do
 
     Broker.publish(%Conduit.Message{}, :message)
 
-    assert_message_publish :message, 10
+    message_name = :message
+    assert_message_publish message_name, 10
   end
 
   test "assert_message_publish/3" do
@@ -101,21 +104,26 @@ defmodule Conduit.TestSharedTest do
 
     Broker.publish(%Conduit.Message{}, :message)
 
-    assert_message_publish(:message, %Conduit.Message{}, 10)
+    message_name = :message
+    assert_message_publish(message_name, %Conduit.Message{}, 10)
   end
 
   test "assert_message_publish/4" do
     Broker.publish(%Conduit.Message{}, :message)
 
     assert_message_publish(:message, %Conduit.Message{}, [to: "somewhere"], 10)
+
+    Broker.publish(%Conduit.Message{}, :message)
+
+    message_name = :message
+    assert_message_publish(message_name, %Conduit.Message{}, [to: "somewhere"], 10)
   end
 
   test "refute_message_publish/1" do
     refute_message_publish :message
 
-    assert capture_io(:stderr, fn ->
-             refute_message_publish %Conduit.Message{}
-           end) =~ "Calling refute_message_publish"
+    message_name = :message
+    refute_message_publish message_name
   end
 
   test "refute_message_publish/2" do
@@ -123,26 +131,34 @@ defmodule Conduit.TestSharedTest do
 
     refute_message_publish :message, 10
 
-    assert capture_io(:stderr, fn ->
-             refute_message_publish %Conduit.Message{}, 10
-           end) =~ "Calling refute_message_publish"
+    message_name = :message
+    refute_message_publish message_name, %Conduit.Message{}
+
+    refute_message_publish message_name, 10
   end
 
   test "refute_message_publish/3" do
     refute_message_publish(:message, %Conduit.Message{}, to: "somewhere")
 
     refute_message_publish(:message, %Conduit.Message{}, 10)
+
+    message_name = :message
+    refute_message_publish(message_name, %Conduit.Message{}, to: "somewhere")
+
+    refute_message_publish(message_name, %Conduit.Message{}, 10)
   end
 
   test "refute_message_publish/4" do
     refute_message_publish(:message, %Conduit.Message{}, [to: "somewhere"], 10)
+
+    message_name = :message
+    refute_message_publish(message_name, %Conduit.Message{}, [to: "somewhere"], 10)
   end
 end
 
 defmodule Conduit.TestUnsharedTest do
   use ExUnit.Case, async: true
   use Conduit.Test, shared: false
-  import ExUnit.CaptureIO
 
   setup do
     Application.put_env(
@@ -169,9 +185,8 @@ defmodule Conduit.TestUnsharedTest do
 
     Broker.publish(%Conduit.Message{}, :message)
 
-    assert capture_io(:stderr, fn ->
-             assert_message_published %Conduit.Message{}
-           end) =~ "Calling assert_message_published"
+    message_name = :message
+    assert_message_published message_name
   end
 
   test "assert_message_published/2" do
@@ -181,35 +196,40 @@ defmodule Conduit.TestUnsharedTest do
 
     Broker.publish(%Conduit.Message{}, :message)
 
-    assert capture_io(:stderr, fn ->
-             assert_message_published %Conduit.Message{}, to: "somewhere"
-           end) =~ "Calling assert_message_published"
+    message_name = :message
+    assert_message_published message_name, %Conduit.Message{}
   end
 
   test "assert_message_published/3" do
     Broker.publish(%Conduit.Message{}, :message)
 
     assert_message_published(:message, %Conduit.Message{}, to: "somewhere")
+
+    Broker.publish(%Conduit.Message{}, :message)
+
+    message_name = :message
+    assert_message_published(message_name, %Conduit.Message{}, to: "somewhere")
   end
 
   test "refute_message_published/1" do
     refute_message_published :message
 
-    assert capture_io(:stderr, fn ->
-             refute_message_published %Conduit.Message{}
-           end) =~ "Calling refute_message_published"
+    message_name = :message
+    refute_message_published message_name
   end
 
   test "refute_message_published/2" do
     refute_message_published :message, %Conduit.Message{}
 
-    assert capture_io(:stderr, fn ->
-             refute_message_published %Conduit.Message{}, to: "somewhere"
-           end) =~ "Calling refute_message_published"
+    message_name = :message
+    refute_message_published message_name, %Conduit.Message{}
   end
 
   test "refute_message_published/3" do
     refute_message_published(:message, %Conduit.Message{}, to: "somewhere")
+
+    message_name = :message
+    refute_message_published(message_name, %Conduit.Message{}, to: "somewhere")
   end
 
   test "assert_message_publish/1" do
@@ -219,9 +239,8 @@ defmodule Conduit.TestUnsharedTest do
 
     Broker.publish(%Conduit.Message{}, :message)
 
-    assert capture_io(:stderr, fn ->
-             assert_message_publish %Conduit.Message{}
-           end) =~ "Calling assert_message_publish"
+    message_name = :message
+    assert_message_publish(message_name)
   end
 
   test "assert_message_publish/2" do
@@ -232,6 +251,15 @@ defmodule Conduit.TestUnsharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     assert_message_publish :message, 10
+
+    Broker.publish(%Conduit.Message{}, :message)
+
+    message_name = :message
+    assert_message_publish message_name, %Conduit.Message{}
+
+    Broker.publish(%Conduit.Message{}, :message)
+
+    assert_message_publish message_name, 10
   end
 
   test "assert_message_publish/3" do
@@ -242,20 +270,33 @@ defmodule Conduit.TestUnsharedTest do
     Broker.publish(%Conduit.Message{}, :message)
 
     assert_message_publish(:message, %Conduit.Message{}, 10)
+
+    Broker.publish(%Conduit.Message{}, :message)
+
+    message_name = :message
+    assert_message_publish(message_name, %Conduit.Message{}, to: "somewhere")
+
+    Broker.publish(%Conduit.Message{}, :message)
+
+    assert_message_publish(message_name, %Conduit.Message{}, 10)
   end
 
   test "assert_message_publish/4" do
     Broker.publish(%Conduit.Message{}, :message)
 
     assert_message_publish(:message, %Conduit.Message{}, [to: "somewhere"], 10)
+
+    Broker.publish(%Conduit.Message{}, :message)
+
+    message_name = :message
+    assert_message_publish(message_name, %Conduit.Message{}, [to: "somewhere"], 10)
   end
 
   test "refute_message_publish/1" do
     refute_message_publish :message
 
-    assert capture_io(:stderr, fn ->
-             refute_message_publish %Conduit.Message{}
-           end) =~ "Calling refute_message_publish"
+    message_name = :message
+    refute_message_publish message_name
   end
 
   test "refute_message_publish/2" do
@@ -263,18 +304,27 @@ defmodule Conduit.TestUnsharedTest do
 
     refute_message_publish :message, 10
 
-    assert capture_io(:stderr, fn ->
-             refute_message_publish %Conduit.Message{}, 10
-           end) =~ "Calling refute_message_publish"
+    message_name = :message
+    refute_message_publish message_name, %Conduit.Message{}
+
+    refute_message_publish message_name, 10
   end
 
   test "refute_message_publish/3" do
     refute_message_publish(:message, %Conduit.Message{}, to: "somewhere")
 
     refute_message_publish(:message, %Conduit.Message{}, 10)
+
+    message_name = :message
+    refute_message_publish(message_name, %Conduit.Message{}, to: "somewhere")
+
+    refute_message_publish(message_name, %Conduit.Message{}, 10)
   end
 
   test "refute_message_publish/4" do
     refute_message_publish(:message, %Conduit.Message{}, [to: "somewhere"], 10)
+
+    message_name = :message
+    refute_message_publish(message_name, %Conduit.Message{}, [to: "somewhere"], 10)
   end
 end


### PR DESCRIPTION
Hi, my team is using this nice library and sometimes we want to test dynamic message names.

I don't know if there's a better way to support this (the code feels repetitive and couldn't keep the deprecated behaviour), so any suggestions are welcome :)